### PR TITLE
fix: remove redundant package name before class

### DIFF
--- a/src/refactoring_guru/composite/example/shapes/CompoundShape.java
+++ b/src/refactoring_guru/composite/example/shapes/CompoundShape.java
@@ -132,7 +132,7 @@ public class CompoundShape extends BaseShape {
             disableSelectionStyle(graphics);
         }
 
-        for (refactoring_guru.composite.example.shapes.Shape child : children) {
+        for (Shape child : children) {
             child.paint(graphics);
         }
     }


### PR DESCRIPTION
Since "Shape" is a public interface, we don't need to explicitly specify the package name before the class. I think this will make the code a little cleaner.