### PR TITLE
fix: add missing @Override annotation in CarBuilder#setCarType

### DIFF
--- a/src/refactoring_guru/builder/example/builders/CarBuilder.java
+++ b/src/refactoring_guru/builder/example/builders/CarBuilder.java
@@ -20,6 +20,7 @@ public class CarBuilder implements Builder {
     private TripComputer tripComputer;
     private GPSNavigator gpsNavigator;
 
+    @Override
     public void setCarType(CarType type) {
         this.type = type;
     }


### PR DESCRIPTION
This PR adds the missing `@Override` annotation to the `setCarType` method in `CarBuilder`.

Although not required, adding the annotation improves consistency with the other methods and makes the example clearer for learners.
